### PR TITLE
Simplify the hook to exclude meta_keys

### DIFF
--- a/post-meta-inspector.php
+++ b/post-meta-inspector.php
@@ -59,8 +59,11 @@ class Post_Meta_Inspector
 				</tr>
 			</thead>
 			<tbody>
-		<?php foreach( $custom_fields as $key => $values ) :
-				if ( apply_filters( 'pmi_ignore_post_meta_key', '__return_false', $key ) )
+		<?php
+		$ignored_keys = apply_filters( 'pmi_ignore_post_meta_key', array( ) );
+
+		foreach( $custom_fields as $key => $values ) :
+				if ( in_array( $key, $ignored_keys ) )
 					continue;
 		?>
 			<?php foreach( $values as $value ) : ?>


### PR DESCRIPTION
This patch makes it easier to exclude multiple meta keys.

It also optimizes the hook so that apply_filters is only called once, instead of once-per-row.

Example of improved hooked usage:

```
add_filter( 'pmi_ignore_post_meta_key', 'example_excluded_keys' );

function example_excluded_keys( $ignored_keys ) {
    $more_keys = array( '_edit_last', '_edit_lock' );
    return $ignored_keys + $more_keys;
}
```
