### PR TITLE
Add filter to post_meta value

### DIFF
--- a/post-meta-inspector.php
+++ b/post-meta-inspector.php
@@ -129,7 +129,8 @@ class Post_Meta_Inspector {
 		?>
 			<?php foreach( $values as $value ) : ?>
 			<?php
-				$value = apply_filter( 'pmi_modify_post_meta_value', var_export( maybe_unserialize( $value ), true ), $key, $value );
+				// filter allows developers to customeize how their meta value should be displayed
+				$value = apply_filter( 'pmi_post_meta_value', var_export( maybe_unserialize( $value ), true ), $key, $value );
 				$toggled = $toggle_length && strlen($value) > $toggle_length;
 			?>
 			<tr>

--- a/post-meta-inspector.php
+++ b/post-meta-inspector.php
@@ -130,7 +130,7 @@ class Post_Meta_Inspector {
 			<?php foreach( $values as $value ) : ?>
 			<?php
 				// filter allows developers to customeize how their meta value should be displayed
-				$value = apply_filter( 'pmi_post_meta_value', var_export( maybe_unserialize( $value ), true ), $key, $value );
+				$value = apply_filters( 'pmi_post_meta_value', var_export( maybe_unserialize( $value ), true ), $key, $value );
 				$toggled = $toggle_length && strlen($value) > $toggle_length;
 			?>
 			<tr>

--- a/post-meta-inspector.php
+++ b/post-meta-inspector.php
@@ -132,11 +132,6 @@ class Post_Meta_Inspector {
 				$value = apply_filter( 'pmi_modify_post_meta_value', var_export( maybe_unserialize( $value ), true ), $key, $value );
 				$toggled = $toggle_length && strlen($value) > $toggle_length;
 			?>
-			<?php foreach ( $values as $value ) : ?>
-				<?php
-				$value   = var_export( $value, true ); // phpcs:ignore
-				$toggled = $toggle_length && strlen( $value ) > $toggle_length;
-				?>
 			<tr>
 				<td class="key-column"><?php echo esc_html( $key ); ?></td>
 				<td class="value-column">

--- a/post-meta-inspector.php
+++ b/post-meta-inspector.php
@@ -93,7 +93,7 @@ class Post_Meta_Inspector
 		?>
 			<?php foreach( $values as $value ) : ?>
 			<?php
-				$value = var_export( $value, true );
+				$value = apply_filter( 'pmi_modify_post_meta_value', var_export( maybe_unserialize( $value ), true ), $key, $value );
 				$toggled = $toggle_length && strlen($value) > $toggle_length;
 			?>
 			<tr>


### PR DESCRIPTION
In some cases it is useful to have a more granular control over what post_meta is shown to the end user. Or modify some values before showing them to the user (json_decode, base64_decode, etc)
