### PR TITLE
Initial Gutenberg compatability

### DIFF
--- a/js/block-editor.js
+++ b/js/block-editor.js
@@ -1,0 +1,26 @@
+var editPost = wp.data.select( 'core/edit-post' ), lastIsSaving = false;
+
+wp.data.subscribe(
+	function() {
+			var isSaving = editPost.isSavingMetaBoxes();
+		if ( isSaving !== lastIsSaving && ! isSaving ) {
+			lastIsSaving = isSaving;
+			// Gutenberg Post Saving has finished!
+			var data = {
+				'action': 'update_post_meta_inspector',
+				'nonce': pmi_data.nonce,
+				'post': pmi_data.post
+			};
+
+			jQuery.get(
+				ajaxurl,
+				data,
+				function( response ) {
+					jQuery( '#post_meta_inspector' ).html( response );
+				}
+			);
+		}
+
+			lastIsSaving = isSaving;
+	}
+);

--- a/js/block-editor.js
+++ b/js/block-editor.js
@@ -21,6 +21,6 @@ wp.data.subscribe(
 			);
 		}
 
-			lastIsSaving = isSaving;
+		lastIsSaving = isSaving;
 	}
 );

--- a/js/block-editor.js
+++ b/js/block-editor.js
@@ -2,7 +2,7 @@ var editPost = wp.data.select( 'core/edit-post' ), lastIsSaving = false;
 
 wp.data.subscribe(
 	function() {
-			var isSaving = editPost.isSavingMetaBoxes();
+		var isSaving = editPost.isSavingMetaBoxes();
 		if ( isSaving !== lastIsSaving && ! isSaving ) {
 			lastIsSaving = isSaving;
 			// Gutenberg Post Saving has finished!

--- a/post-meta-inspector.php
+++ b/post-meta-inspector.php
@@ -91,7 +91,7 @@ class Post_Meta_Inspector {
 	 * @return void
 	 */
 	public function post_meta_inspector() {
-		$post_id = isset( $_GET['post'] ) ? (int) $_GET['post'] : get_the_ID();
+		$post_id = isset( $_GET['post'] ) ? (int) $_GET['post'] : get_the_ID(); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 		?>
 		<style>
 			#post-meta-inspector table {
@@ -145,11 +145,16 @@ class Post_Meta_Inspector {
 		<?php
 	}
 
+	/**
+	 * Renders the Post Meta table.
+	 *
+	 * @return void
+	 */
 	public function render_table() {
-		$post_id       = isset( $_GET['post'] ) ? (int) $_GET['post'] : get_the_ID();
-		$custom_fields = get_post_meta( $post_id );
-		$toggle_length = apply_filters( 'pmi_toggle_long_value_length', 0 );
-		$toggle_length = max( intval($toggle_length), 0);
+		$post_id           = isset( $_GET['post'] ) ? (int) $_GET['post'] : get_the_ID();
+		$custom_fields     = get_post_meta( $post_id );
+		$toggle_length     = apply_filters( 'pmi_toggle_long_value_length', 0 );
+		$toggle_length     = max( intval( $toggle_length ), 0 );
 		$toggle_el_escaped = '<a href="javascript:void(0);" class="pmi_toggle">' . esc_html__( 'Click to show&hellip;', 'post-meta-inspector' ) . '</a>';
 
 		if ( wp_doing_ajax() ) {
@@ -164,19 +169,26 @@ class Post_Meta_Inspector {
 				</tr>
 			</thead>
 			<tbody>
-		<?php foreach( $custom_fields as $key => $values ) :
-				if ( apply_filters( 'pmi_ignore_post_meta_key', false, $key ) ) {
-					continue;
-				}
-		?>
-			<?php foreach( $values as $value ) : ?>
-			<?php
-				$value = var_export( $value, true );
-				$toggled = $toggle_length && strlen($value) > $toggle_length;
+		<?php
+		foreach ( $custom_fields as $key => $values ) :
+			if ( apply_filters( 'pmi_ignore_post_meta_key', false, $key ) ) {
+				continue;
+			}
 			?>
+			<?php foreach ( $values as $value ) : ?>
+				<?php
+				$value   = var_export( $value, true ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+				$toggled = $toggle_length && strlen( $value ) > $toggle_length;
+				?>
 			<tr>
 				<td class="key-column"><?php echo esc_html( $key ); ?></td>
-				<td class="value-column"><?php if( $toggled ) echo $toggle_el_escaped; ?><code <?php if( $toggled ) echo ' style="display: none;"'; ?>><?php echo esc_html( $value ); ?></code></td>
+				<td class="value-column">
+				<?php
+				if ( $toggled ) {
+					echo $toggle_el_escaped; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				}
+				?>
+				<code <?php echo $toggled ? ' style="display: none;"' : ''; ?>><?php echo esc_html( $value ); ?></code></td>
 			</tr>
 			<?php endforeach; ?>
 		<?php endforeach; ?>


### PR DESCRIPTION
This updates the meta box to refresh the meta table when a Gutenberg post is saved.  It does this very simply by just re-requesting the table HTML, rather than getting fancy with something like a JSON object and parsing it into DOM bits.  Not elegant, but simple.

Might fix #17.  Thoughts @danielbachhuber?