### PR TITLE
Do not add meta-box to pages without a post type

### DIFF
--- a/post-meta-inspector.php
+++ b/post-meta-inspector.php
@@ -75,9 +75,10 @@ class Post_Meta_Inspector {
 	 * Add the post meta box to view post meta if the user has permissions to
 	 */
 	public function action_add_meta_boxes() {
-
+		$post_type = get_post_type();
 		$this->view_cap = apply_filters( 'pmi_view_cap', 'manage_options' );
-		if ( ! current_user_can( $this->view_cap ) || ! apply_filters( 'pmi_show_post_type', '__return_true', get_post_type() ) ) {
+
+		if ( empty( $post_type ) || ! current_user_can( $this->view_cap ) || ! apply_filters( 'pmi_show_post_type', '__return_true', $post_type ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Reported here: https://github.com/stuttter/wp-user-profiles/issues/22

The meta box UI is not necessarily specific to Posts. Many plugins (including some of mine) repurpose that UI for other areas of WordPress admin.

This commit is one way to avoid a PHP Warning for: `Invalid argument supplied for foreach()` when both this plugin and my WP User Profiles plugin are active at the same time.